### PR TITLE
CVP-3890 Quote values to match expected format

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,8 +4,8 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: gatekeeper-operator
-  operators.operatorframework.io.bundle.channels.v1: 3.11
-  operators.operatorframework.io.bundle.channel.default.v1: 3.11
+  operators.operatorframework.io.bundle.channels.v1: "3.11"
+  operators.operatorframework.io.bundle.channel.default.v1: "3.11"
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3


### PR DESCRIPTION
## Summary of Changes

The bundle validation scripts expect channel names to be a string in yaml as opposed to a float - so we need to double quote these values!  