### PR TITLE
E2E tweaks

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -72,7 +72,6 @@ jobs:
 
     - name: Create K8s KinD Cluster
       run: |
-        kind version
         make test-cluster
 
     - name: Build and Push Test Container Image to KIND node
@@ -123,7 +122,6 @@ jobs:
 
     - name: Create K8s KinD Cluster
       run: |
-        kind version
         make test-cluster
 
     - name: Build and Push Test Container Image to KIND node

--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -346,6 +346,8 @@ spec:
           strategy: {}
           template:
             metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
               labels:
                 control-plane: gatekeeper-operator-controller-manager
             spec:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,6 +19,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
     spec:

--- a/deploy/gatekeeper-operator.yaml
+++ b/deploy/gatekeeper-operator.yaml
@@ -1684,6 +1684,8 @@ spec:
       control-plane: gatekeeper-operator-controller-manager
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: gatekeeper-operator-controller-manager
     spec:

--- a/test/e2e/gatekeeper_controller_test.go
+++ b/test/e2e/gatekeeper_controller_test.go
@@ -273,10 +273,6 @@ var _ = Describe("Gatekeeper", func() {
 				Expect(auditDeployment.Spec.Replicas).NotTo(BeNil())
 				Expect(auditDeployment.Spec.Replicas).To(Equal(gatekeeper.Spec.Audit.Replicas))
 				Expect(webhookDeployment.Spec.Replicas).NotTo(BeNil())
-				// TODO: Remove once flake has been fixed. See
-				// https://github.com/gatekeeper/gatekeeper-operator/pull/168/checks?check_run_id=2918723659
-				// for example failure.
-				fmt.Fprint(GinkgoWriter, "webhookDeployment", webhookDeployment)
 				Expect(webhookDeployment.Spec.Replicas).To(Equal(gatekeeper.Spec.Webhook.Replicas))
 			})
 


### PR DESCRIPTION
- Reset manifests after apply
- Remove debug logs from E2E test
- Set the default container for `kubectl logs`
- Update `kind-with-registry.sh` to be reusable