### PR TITLE
Release v3.11.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 3.11.1-2
+VERSION ?= 3.11.2
 # Replaces Operator version
 # Set this when when there is a new patch release in the channel.
-REPLACES_VERSION ?= 0.2.6
+REPLACES_VERSION ?= 3.11.1
 
 LOCAL_BIN ?= $(PWD)/ci-tools/bin
 export PATH := $(LOCAL_BIN):$(PATH)

--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -19,7 +19,7 @@ metadata:
     olm.skipRange: "<3.11.0"
     operators.operatorframework.io/builder: operator-sdk-v1.28.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: gatekeeper-operator.v3.11.1-2
+  name: gatekeeper-operator.v3.11.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -376,7 +376,7 @@ spec:
                 env:
                 - name: RELATED_IMAGE_GATEKEEPER
                   value: openpolicyagent/gatekeeper:v3.11.1
-                image: quay.io/gatekeeper/gatekeeper-operator:v3.11.1-2
+                image: quay.io/gatekeeper/gatekeeper-operator:v3.11.2
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -514,5 +514,5 @@ spec:
   relatedImages:
   - image: openpolicyagent/gatekeeper:v3.11.1
     name: gatekeeper
-  replaces: gatekeeper-operator.v0.2.6
-  version: "3.11.1-2"
+  replaces: gatekeeper-operator.v3.11.1
+  version: "3.11.2"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,4 +14,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/gatekeeper/gatekeeper-operator
-  newTag: v3.11.1-2
+  newTag: v3.11.2

--- a/deploy/gatekeeper-operator.yaml
+++ b/deploy/gatekeeper-operator.yaml
@@ -1713,7 +1713,7 @@ spec:
         env:
         - name: RELATED_IMAGE_GATEKEEPER
           value: openpolicyagent/gatekeeper:v3.11.1
-        image: quay.io/gatekeeper/gatekeeper-operator:v3.11.1-2
+        image: quay.io/gatekeeper/gatekeeper-operator:v3.11.2
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Followup (and reverts):
- #42 

(Using the `-*` version metadata would replace the original `vX.Y.Z` image, which was an unintended outcome.)