### PR TITLE
Remove `/` for push in fast-forward workflow

### DIFF
--- a/.github/workflows/fast_forward.yaml
+++ b/.github/workflows/fast_forward.yaml
@@ -23,7 +23,7 @@ jobs:
       run: |
         git checkout ${RELEASE_BRANCH} || git checkout -b ${RELEASE_BRANCH}
         git merge --ff-only origin/main
-        git push origin/${RELEASE_BRANCH}
+        git push origin ${RELEASE_BRANCH}
 
     - name: Slack failure report
       uses: slackapi/slack-github-action@v1.23.0


### PR DESCRIPTION
Followup to:
- #48 