### PR TITLE
Checkout with token for fast-forward

### DIFF
--- a/.github/workflows/fast_forward.yaml
+++ b/.github/workflows/fast_forward.yaml
@@ -12,6 +12,7 @@ jobs:
     steps:    
     - uses: actions/checkout@v3
       with:
+        token: ${{ secrets.WORKFLOW_TOKEN }}
         fetch-depth: 0 # Fetch all history for all tags and branches
 
     - name: Set Up Environment Variables


### PR DESCRIPTION
Permissions on fast-forwarding weren't allowing the push to a release branch.

Followup to:
- #48 