### PR TITLE
Increase memory limit for ROSA/HCP env

### DIFF
--- a/config/gatekeeper/kustomization.yaml
+++ b/config/gatekeeper/kustomization.yaml
@@ -29,17 +29,17 @@ resources:
 - apiextensions.k8s.io_v1_customresourcedefinition_assignimage.mutations.gatekeeper.sh.yaml
 # Remove --disable-cert-rotation
 # Set a CPU limit
+# Increase default Memory limit
 patches:
-- patch: |-
-    - op: remove
-      path: /spec/template/spec/containers/0/args/5
-  target:
-    kind: Deployment
-    name: gatekeeper-audit
 - patch: |-
     - op: replace
       path: /spec/template/spec/containers/0/resources/limits/cpu
       value: 1000m
+    - op: replace
+      path: /spec/template/spec/containers/0/resources/limits/memory
+      value: 1Gi
+    - op: remove
+      path: /spec/template/spec/containers/0/args/5
   target:
     kind: Deployment
     name: gatekeeper-audit

--- a/controllers/gatekeeper_controller_test.go
+++ b/controllers/gatekeeper_controller_test.go
@@ -557,18 +557,18 @@ func TestResources(t *testing.T) {
 	// test default resources
 	auditObj, err := util.GetManifestObject(AuditFile)
 	g.Expect(err).ToNot(HaveOccurred())
-	assertResources(g, auditObj, nil)
+	assertResources(g, auditObj, test.DefaultDeployment.AuditResources)
 	webhookObj, err := util.GetManifestObject(WebhookFile)
 	g.Expect(err).ToNot(HaveOccurred())
-	assertResources(g, webhookObj, nil)
+	assertResources(g, webhookObj, test.DefaultDeployment.WebResources)
 
 	// test nil resources
 	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
-	assertResources(g, auditObj, nil)
+	assertResources(g, auditObj, test.DefaultDeployment.AuditResources)
 	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
-	assertResources(g, webhookObj, nil)
+	assertResources(g, webhookObj, test.DefaultDeployment.WebResources)
 
 	// test resources override
 	gatekeeper.Spec.Audit = audit
@@ -592,11 +592,8 @@ func assertResources(g *WithT, obj *unstructured.Unstructured, expected *corev1.
 		current, found, err := unstructured.NestedMap(util.ToMap(c), "resources")
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(found).To(BeTrue())
-		if expected == nil {
-			assertResource(g, test.DefaultDeployment.Resources, current)
-		} else {
-			assertResource(g, expected, current)
-		}
+
+		assertResource(g, expected, current)
 	}
 }
 

--- a/pkg/bindata/bindata.go
+++ b/pkg/bindata/bindata.go
@@ -4926,7 +4926,7 @@ spec:
         resources:
           limits:
             cpu: 1000m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 512Mi

--- a/test/e2e/gatekeeper_controller_test.go
+++ b/test/e2e/gatekeeper_controller_test.go
@@ -199,8 +199,8 @@ var _ = Describe("Gatekeeper", func() {
 			})
 
 			By("Checking default resource limits and requests", func() {
-				assertResources(*test.DefaultDeployment.Resources, auditDeployment.Spec.Template.Spec.Containers[0].Resources)
-				assertResources(*test.DefaultDeployment.Resources, webhookDeployment.Spec.Template.Spec.Containers[0].Resources)
+				assertResources(*test.DefaultDeployment.AuditResources, auditDeployment.Spec.Template.Spec.Containers[0].Resources)
+				assertResources(*test.DefaultDeployment.WebResources, webhookDeployment.Spec.Template.Spec.Containers[0].Resources)
 			})
 
 			By("Checking default image", func() {

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -39,7 +39,8 @@ type defaultConfig struct {
 	Affinity          *corev1.Affinity
 	NodeSelector      map[string]string
 	PodAnnotations    map[string]string
-	Resources         *corev1.ResourceRequirements
+	WebResources      *corev1.ResourceRequirements
+	AuditResources    *corev1.ResourceRequirements
 	FailurePolicy     admregv1.FailurePolicyType
 	NamespaceSelector *metav1.LabelSelector
 }
@@ -74,7 +75,17 @@ var DefaultDeployment = defaultConfig{
 	NodeSelector: map[string]string{
 		"kubernetes.io/os": "linux",
 	},
-	Resources: &corev1.ResourceRequirements{
+	AuditResources: &corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1000m"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	},
+	WebResources: &corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("1000m"),
 			corev1.ResourceMemory: resource.MustParse("512Mi"),


### PR DESCRIPTION
In ROSA/HCP env, the gatekeeper-audit pod failed with OOMKilled. 
This PR increases the memory limit to 1Gi to fix this issue. 

Ref: https://issues.redhat.com/browse/ACM-9757
