### PR TITLE
Change from openpolicyagent to quay.io/gateekeeper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ TMP_IMPORT_MANIFESTS_PATH := $(shell mktemp -d)
 import-manifests: kustomize
 	if [[ $(IMPORT_MANIFESTS_PATH) =~ https://* ]]; then \
 		git clone --branch v$(GATEKEEPER_VERSION)  $(IMPORT_MANIFESTS_PATH) $(TMP_IMPORT_MANIFESTS_PATH) ; \
-		cd $(TMP_IMPORT_MANIFESTS_PATH) && make patch-image ; \
+		cd $(TMP_IMPORT_MANIFESTS_PATH) && make patch-image && $(SED) -i 's/openpolicyagent/quay.io\/gatekeeper/g' config/manager/manager.yaml ; \
 		$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone $(TMP_IMPORT_MANIFESTS_PATH)/config/default -o $(MAKEFILE_DIR)/$(GATEKEEPER_MANIFEST_DIR); \
 		rm -rf "$${TMP_IMPORT_MANIFESTS_PATH}" ; \
 	else \

--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -390,7 +390,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_GATEKEEPER
-                  value: openpolicyagent/gatekeeper:v3.14.1
+                  value: quay.io/gatekeeper/gatekeeper:v3.14.1
                 image: quay.io/gatekeeper/gatekeeper-operator:v3.14.1
                 imagePullPolicy: Always
                 livenessProbe:
@@ -527,7 +527,7 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: openpolicyagent/gatekeeper:v3.14.1
+  - image: quay.io/gatekeeper/gatekeeper:v3.14.1
     name: gatekeeper
   replaces: gatekeeper-operator.v3.14.0
   version: "3.14.1"

--- a/config/gatekeeper/apps_v1_deployment_gatekeeper-audit.yaml
+++ b/config/gatekeeper/apps_v1_deployment_gatekeeper-audit.yaml
@@ -49,7 +49,7 @@ spec:
               fieldPath: metadata.namespace
         - name: CONTAINER_NAME
           value: manager
-        image: openpolicyagent/gatekeeper:v3.14.1
+        image: quay.io/gatekeeper/gatekeeper:v3.14.1
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/config/gatekeeper/apps_v1_deployment_gatekeeper-controller-manager.yaml
+++ b/config/gatekeeper/apps_v1_deployment_gatekeeper-controller-manager.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: CONTAINER_NAME
           value: manager
-        image: openpolicyagent/gatekeeper:v3.14.1
+        image: quay.io/gatekeeper/gatekeeper:v3.14.1
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -60,6 +60,6 @@ spec:
             memory: 20Mi
         env:
         - name: RELATED_IMAGE_GATEKEEPER
-          value: openpolicyagent/gatekeeper:v3.14.1
+          value: quay.io/gatekeeper/gatekeeper:v3.14.1
       serviceAccountName: gatekeeper-operator-controller-manager
       terminationGracePeriodSeconds: 10

--- a/deploy/gatekeeper-operator.yaml
+++ b/deploy/gatekeeper-operator.yaml
@@ -1768,7 +1768,7 @@ spec:
         - /manager
         env:
         - name: RELATED_IMAGE_GATEKEEPER
-          value: openpolicyagent/gatekeeper:v3.14.1
+          value: quay.io/gatekeeper/gatekeeper:v3.14.1
         image: quay.io/gatekeeper/gatekeeper-operator:v3.14.1
         imagePullPolicy: Always
         livenessProbe:

--- a/docs/upgrading-gatekeeper.md
+++ b/docs/upgrading-gatekeeper.md
@@ -34,7 +34,7 @@ git commit -m "Set Gatekeeper version to ${GATEKEEPER_VERSION}" Makefile
 ## 2. Update Operator deployment's Gatekeeper image environment variable
 
 ```shell
-sed -Ei "s|(value: openpolicyagent/gatekeeper:)${GATEKEEPER_PREV_VERSION}|\1${GATEKEEPER_VERSION}|" ./config/manager/manager.yaml
+sed -Ei "s|(value: quay.io/gatekeeper/gatekeeper:)${GATEKEEPER_PREV_VERSION}|\1${GATEKEEPER_VERSION}|" ./config/manager/manager.yaml
 git commit -m "Update deployed Gatekeeper image to ${GATEKEEPER_VERSION}" ./config/manager/manager.yaml
 ```
 

--- a/pkg/bindata/bindata.go
+++ b/pkg/bindata/bindata.go
@@ -4905,7 +4905,7 @@ spec:
               fieldPath: metadata.namespace
         - name: CONTAINER_NAME
           value: manager
-        image: openpolicyagent/gatekeeper:v3.14.1
+        image: quay.io/gatekeeper/gatekeeper:v3.14.1
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -5039,7 +5039,7 @@ spec:
               fieldPath: metadata.namespace
         - name: CONTAINER_NAME
           value: manager
-        image: openpolicyagent/gatekeeper:v3.14.1
+        image: quay.io/gatekeeper/gatekeeper:v3.14.1
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Change the image from openpolicyagent to quay.io/gateekeeper
For now, our dev is using a gatekeeper image from openpolicyagent/gatekeeper in gatekeeper-operator
This should be changed to stolostron
Signed-off-by: yiraeChristineKim <yikim@redhat.com>