### PR TITLE
Change from openpolicyagent to quay.io/gateekeeper

### DIFF
--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -406,7 +406,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_GATEKEEPER
-                  value: openpolicyagent/gatekeeper:v3.15.1
+                  value: quay.io/gatekeeper/gatekeeper:v3.15.1
                 image: quay.io/gatekeeper/gatekeeper-operator:v3.15.1
                 imagePullPolicy: Always
                 livenessProbe:
@@ -543,7 +543,7 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: openpolicyagent/gatekeeper:v3.15.1
+  - image: quay.io/gatekeeper/gatekeeper:v3.15.1
     name: gatekeeper
   replaces: gatekeeper-operator.v3.14.1
   version: "3.15.1"

--- a/config/gatekeeper/apps_v1_deployment_gatekeeper-audit.yaml
+++ b/config/gatekeeper/apps_v1_deployment_gatekeeper-audit.yaml
@@ -51,7 +51,7 @@ spec:
           value: manager
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE),k8s.container.name=$(CONTAINER_NAME)
-        image: openpolicyagent/gatekeeper:v3.15.1
+        image: quay.io/gatekeeper/gatekeeper:v3.15.1
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/config/gatekeeper/apps_v1_deployment_gatekeeper-controller-manager.yaml
+++ b/config/gatekeeper/apps_v1_deployment_gatekeeper-controller-manager.yaml
@@ -63,7 +63,7 @@ spec:
           value: manager
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE),k8s.container.name=$(CONTAINER_NAME)
-        image: openpolicyagent/gatekeeper:v3.15.1
+        image: quay.io/gatekeeper/gatekeeper:v3.15.1
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -60,6 +60,6 @@ spec:
               memory: 20Mi
           env:
             - name: RELATED_IMAGE_GATEKEEPER
-              value: openpolicyagent/gatekeeper:v3.15.1
+              value: quay.io/gatekeeper/gatekeeper:v3.15.1
       serviceAccountName: gatekeeper-operator-controller-manager
       terminationGracePeriodSeconds: 10

--- a/deploy/gatekeeper-operator.yaml
+++ b/deploy/gatekeeper-operator.yaml
@@ -1762,7 +1762,7 @@ spec:
         - /manager
         env:
         - name: RELATED_IMAGE_GATEKEEPER
-          value: openpolicyagent/gatekeeper:v3.15.1
+          value: quay.io/gatekeeper/gatekeeper:v3.15.1
         image: quay.io/gatekeeper/gatekeeper-operator:v3.15.1
         imagePullPolicy: Always
         livenessProbe:

--- a/pkg/bindata/bindata.go
+++ b/pkg/bindata/bindata.go
@@ -4988,7 +4988,7 @@ spec:
           value: manager
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE),k8s.container.name=$(CONTAINER_NAME)
-        image: openpolicyagent/gatekeeper:v3.15.1
+        image: quay.io/gatekeeper/gatekeeper:v3.15.1
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -5124,7 +5124,7 @@ spec:
           value: manager
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE),k8s.container.name=$(CONTAINER_NAME)
-        image: openpolicyagent/gatekeeper:v3.15.1
+        image: quay.io/gatekeeper/gatekeeper:v3.15.1
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Change the image from openpolicyagent to quay.io/gateekeeper For now, our dev is using a gatekeeper image from openpolicyagent/gatekeeper in gatekeeper-operator This should be changed to stolostron
Ref: https://issues.redhat.com/browse/ACM-9099
Signed-off-by: yiraeChristineKim <yikim@redhat.com>