### PR TITLE
🐛 [Manual cherrypick]Fix secret name for openshift mode

### DIFF
--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -93,6 +93,7 @@ const (
 	DisabledBuiltinArg                  = "--disable-opa-builtin"
 	LogMutationsArg                     = "--log-mutations"
 	MutationAnnotationsArg              = "--mutation-annotations"
+	OpenshiftSecretName                 = "gatekeeper-webhook-server-cert-ocp"
 )
 
 var (
@@ -620,7 +621,7 @@ func setOpenshiftCertAnnotation(obj *unstructured.Unstructured) {
 		annotations = make(map[string]string, 1)
 	}
 
-	annotations["service.beta.openshift.io/serving-cert-secret-name"] = "gatekeeper-webhook-server-cert"
+	annotations["service.beta.openshift.io/serving-cert-secret-name"] = OpenshiftSecretName
 
 	obj.SetAnnotations(annotations)
 }
@@ -895,7 +896,31 @@ func openShiftDeploymentOverrides(obj *unstructured.Unstructured) error {
 
 	err = unstructured.SetNestedField(obj.Object, containers, "spec", "template", "spec", "containers")
 	if err != nil {
-		return errors.Wrapf(err, "Failed to set the OpenShift overrides")
+		return errors.Wrapf(err, "Failed to set the OpenShift overrides for the Deployment containers")
+	}
+
+	const volumeErrMsg = "Failed to set the certificate volume mount for OpenShift"
+
+	volumes, _, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "volumes")
+	if err != nil || len(volumes) == 0 {
+		return errors.Wrapf(err, volumeErrMsg)
+	}
+
+	vol, ok := volumes[0].(map[string]interface{})
+	if !ok {
+		return errors.Wrapf(err, "Failed to parse volumes")
+	}
+
+	err = unstructured.SetNestedField(vol, OpenshiftSecretName, "secret", "secretName")
+	if err != nil {
+		return errors.Wrapf(err, volumeErrMsg)
+	}
+
+	volumes[0] = vol
+
+	err = unstructured.SetNestedField(obj.Object, volumes, "spec", "template", "spec", "volumes")
+	if err != nil {
+		return errors.Wrapf(err, volumeErrMsg)
 	}
 
 	return nil

--- a/test/e2e/gatekeeper_controller_test.go
+++ b/test/e2e/gatekeeper_controller_test.go
@@ -137,6 +137,11 @@ var _ = Describe("Gatekeeper", func() {
 
 			auditDeployment, webhookDeployment := gatekeeperDeployments()
 
+			By("Checking the first element of deployment.volume is about certification", func() {
+				Expect(auditDeployment.Spec.Template.Spec.Volumes[0].Secret.SecretName).NotTo(Equal(""))
+				Expect(webhookDeployment.Spec.Template.Spec.Volumes[0].Secret.SecretName).NotTo(Equal(""))
+			})
+
 			By("Checking default replicas", func() {
 				Expect(auditDeployment.Spec.Replicas).NotTo(BeNil())
 				Expect(*auditDeployment.Spec.Replicas).To(Equal(test.DefaultDeployment.AuditReplicas))
@@ -557,6 +562,7 @@ var _ = Describe("Gatekeeper", func() {
 	Describe("Test in Openshift Env", Label("openshift"), Ordered, Serial, func() {
 		const openshiftRoutePath = "../resources/gatekeeper_test/openshift-route-crd.yaml"
 		const openshiftNamespace = "openshift-gatekeeper-system"
+
 		Describe("Test Gatekeeper Certification", Label("openshift"), func() {
 			It("Should have Openshift Cert Annotation in the Service Resource"+
 				"and not have Cert Secret in the Gatekeeper Namespace", func(ctx context.Context) {
@@ -565,7 +571,8 @@ var _ = Describe("Gatekeeper", func() {
 					Expect(K8sClient.Create(ctx, gatekeeper)).Should(Succeed())
 				})
 
-				By("All Deployment resources should have a --disable-cert-rotation arg")
+				By("All Deployment resources should have a --disable-cert-rotation arg" +
+					" and cert secret name for openshift")
 				Eventually(func(g Gomega) {
 					audit := &appsv1.Deployment{}
 					err := K8sClient.Get(ctx, types.NamespacedName{
@@ -576,6 +583,9 @@ var _ = Describe("Gatekeeper", func() {
 
 					g.Expect(audit.Spec.Template.Spec.Containers[0].Args).
 						Should(ContainElement("--disable-cert-rotation"), "Audit should have disabled cert arg")
+					g.Expect(audit.Spec.Template.Spec.Volumes[0].Secret.SecretName).
+						Should(Equal(controllers.OpenshiftSecretName),
+							"Audit deployment certificate volume mount should have the expected name")
 				}, timeout, pollInterval).Should(Succeed())
 
 				Eventually(func(g Gomega) {
@@ -588,6 +598,9 @@ var _ = Describe("Gatekeeper", func() {
 
 					g.Expect(webhook.Spec.Template.Spec.Containers[0].Args).
 						Should(ContainElement("--disable-cert-rotation"), "Webhook should have disabled cert arg")
+					g.Expect(webhook.Spec.Template.Spec.Volumes[0].Secret.SecretName).
+						Should(Equal(controllers.OpenshiftSecretName),
+							"Webhook deployment certificate volume mount should have the expected name")
 				}, timeout, pollInterval).Should(Succeed())
 
 				By("Service resource should have a service.beta.openshift.io/serving-cert-secret-name annotation")
@@ -605,8 +618,8 @@ var _ = Describe("Gatekeeper", func() {
 					v, ok := annotations["service.beta.openshift.io/serving-cert-secret-name"]
 					g.Expect(ok).Should(BeTrue(),
 						"Should have service.beta.openshift.io/serving-cert-secret-name annotation")
-					g.Expect(v).Should(Equal("gatekeeper-webhook-server-cert"),
-						"Should be gatekeeper-webhook-server-cert")
+					g.Expect(v).Should(Equal(controllers.OpenshiftSecretName),
+						"service.beta.openshift.io/serving-cert-secret-name should have the expected value")
 				}, timeout, pollInterval).Should(Succeed())
 
 				By("ValidatingWebhookConfiguration should have a service.beta.openshift.io/inject-cabundle annotation")


### PR DESCRIPTION
Upgrading the gatekeeper causes cert-issue  due to the fact that the same secret name has been created by the service-ca already Ref: https://issues.redhat.com/browse/ACM-11413
Signed-off-by: yiraeChristineKim <yikim@redhat.com>