### PR TITLE
Catch not found mutating webhook deletion error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OLM_VERSION ?= v0.27.0
 # https://github.com/operator-framework/operator-sdk/releases/latest
 OPERATOR_SDK_VERSION ?= v1.34.1
 # https://github.com/kubernetes/kubernetes/releases/latest
-KUBERNETES_VERSION ?= v1.29.0
+KUBERNETES_VERSION ?= v1.29.4
 # https://github.com/bats-core/bats-core/releases/latest
 BATS_VERSION ?= 1.11.0
 

--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -593,7 +593,9 @@ func (r *GatekeeperReconciler) crudResource(
 		}
 	case deleteCrud:
 		if err = r.Delete(ctx, obj); err != nil {
-			return errors.Wrapf(err, "Error attempting to delete resource %s", namespacedName)
+			if !apierrors.IsNotFound(err) {
+				return errors.Wrapf(err, "Error attempting to delete resource %s", namespacedName)
+			}
 		}
 
 		logger.Info("Deleted Gatekeeper resource")

--- a/test/e2e/gatekeeper_controller_test.go
+++ b/test/e2e/gatekeeper_controller_test.go
@@ -984,7 +984,8 @@ func byCheckingMutationDisabled(ctx SpecContext, auditDeployment, webhookDeploym
 			)
 
 			return found
-		}, timeout, pollInterval).Should(BeFalse())
+		}, timeout, pollInterval).Should(BeFalse(),
+			fmt.Sprintf("Argument %s should not be set", controllers.EnableMutationArg))
 	})
 
 	By(fmt.Sprintf("Checking %s=%s argument is set",
@@ -996,7 +997,10 @@ func byCheckingMutationDisabled(ctx SpecContext, auditDeployment, webhookDeploym
 				controllers.OperationArg, controllers.OperationMutationStatus)
 
 			return found
-		}, timeout, pollInterval).Should(BeTrue())
+		}, timeout, pollInterval).Should(BeTrue(),
+			fmt.Sprintf("Should have argument %s=%s",
+				controllers.OperationArg, controllers.OperationMutationStatus),
+		)
 	})
 
 	By("Checking MutatingWebhookConfiguration not deployed", func() {
@@ -1005,7 +1009,7 @@ func byCheckingMutationDisabled(ctx SpecContext, auditDeployment, webhookDeploym
 			err := K8sClient.Get(ctx, mutatingWebhookName, mutatingWebhookConfiguration)
 
 			return apierrors.IsNotFound(err)
-		}, timeout, pollInterval).Should(BeTrue())
+		}, timeout, pollInterval).Should(BeTrue(), "MutatingWebhookConfiguration should not exist")
 	})
 
 	crdFn := func(crdName types.NamespacedName, mutatingCRD *extv1.CustomResourceDefinition) {
@@ -1013,7 +1017,7 @@ func byCheckingMutationDisabled(ctx SpecContext, auditDeployment, webhookDeploym
 			err := K8sClient.Get(ctx, crdName, mutatingCRD)
 
 			return apierrors.IsNotFound(err)
-		}, timeout, pollInterval).Should(BeTrue())
+		}, timeout, pollInterval).Should(BeTrue(), "CRD "+crdName.Name+" should not exist")
 	}
 	byCheckingMutatingCRDs("not deployed", crdFn)
 }


### PR DESCRIPTION
It doesn't need to be cherry-picked--it was errantly removed during a refactor in https://github.com/stolostron/gatekeeper-operator/commit/6cb6b72b458fd9eb8ffb4a10622e253fa8a25106

ref: https://issues.redhat.com/browse/ACM-11999