### PR TITLE
Add tests for deploying with disabled webhooks (and then some)

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -3,12 +3,12 @@ name: CI-Tests
 on:
   push:
     branches:
-    - main
-    - release-[0-9]+.[0-9]+
+      - main
+      - release-[0-9]+.[0-9]+
   pull_request:
     branches:
-    - main
-    - release-[0-9]+.[0-9]+
+      - main
+      - release-[0-9]+.[0-9]+
 
 defaults:
   run:
@@ -20,146 +20,146 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
-    - name: Verify modules
-      run: |
-        go mod tidy
-        go mod verify
-        git diff --exit-code
+      - name: Verify modules
+        run: |
+          go mod tidy
+          go mod verify
+          git diff --exit-code
 
-    - name: Verify format
-      run: |
-        make fmt
-        git diff --exit-code
-        make lint
+      - name: Verify format
+        run: |
+          make fmt
+          git diff --exit-code
+          make lint
 
-    - name: Verify manifests
-      run: |
-        make manifests
-        git diff --exit-code
+      - name: Verify manifests
+        run: |
+          make manifests
+          git diff --exit-code
 
-    - name: Verify imported manifests
-      run: |
-        make import-manifests
-        git diff --exit-code
+      - name: Verify imported manifests
+        run: |
+          make import-manifests
+          git diff --exit-code
 
-    - name: Verify bindata
-      run: |
-        make update-bindata
-        git diff --exit-code
+      - name: Verify bindata
+        run: |
+          make update-bindata
+          git diff --exit-code
 
-    - name: Unit and Integration Tests
-      run: |
-        make test
+      - name: Unit and Integration Tests
+        run: |
+          make test
 
-        echo "::group::Test coverage"
-        make test-coverage
-        echo "::endgroup::"
+          echo "::group::Test coverage"
+          make test-coverage
+          echo "::endgroup::"
 
-    - name: Run Gosec Security Scanner
-      uses: securego/gosec@v2.20.0
-      with:
-        args: -no-fail -fmt sonarqube -out gosec.json -stdout -exclude-dir=.go -exclude-dir=test ./...
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@v2.20.0
+        with:
+          args: -no-fail -fmt sonarqube -out gosec.json -stdout -exclude-dir=.go -exclude-dir=test ./...
 
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: artifacts
-        path: |
-          gosec.json
-          coverage_unit.out
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts
+          path: |
+            gosec.json
+            coverage_unit.out
 
   e2e-tests:
     name: Run e2e tests
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
-    - name: Download binaries
-      run: |
-        make download-binaries
+      - name: Download binaries
+        run: |
+          make download-binaries
 
-    - name: Create K8s KinD Cluster
-      run: |
-        make test-cluster
+      - name: Create K8s KinD Cluster
+        run: |
+          make test-cluster
 
-    - name: Build and Push Test Container Image to KIND node
-      run: |
-        make docker-build IMG=localhost:5000/gatekeeper-operator:$GITHUB_SHA
-        kind load docker-image localhost:5000/gatekeeper-operator:$GITHUB_SHA
+      - name: Build and Push Test Container Image to KIND node
+        run: |
+          make docker-build IMG=localhost:5000/gatekeeper-operator:$GITHUB_SHA
+          kind load docker-image localhost:5000/gatekeeper-operator:$GITHUB_SHA
 
-    - name: E2E Tests
-      run: |
-        make deploy-ci NAMESPACE=gatekeeper-system IMG=localhost:5000/gatekeeper-operator:$GITHUB_SHA
-        kubectl -n gatekeeper-system wait deployment/gatekeeper-operator-controller --for condition=Available --timeout=90s
-        kubectl -n gatekeeper-system logs deployment/gatekeeper-operator-controller -c manager -f 2>&1 | tee operator.log &
-        make test-e2e NAMESPACE=gatekeeper-system
+      - name: E2E Tests
+        run: |
+          make deploy-ci NAMESPACE=gatekeeper-system IMG=localhost:5000/gatekeeper-operator:$GITHUB_SHA
+          kubectl -n gatekeeper-system wait deployment/gatekeeper-operator-controller --for condition=Available --timeout=90s
+          kubectl -n gatekeeper-system logs deployment/gatekeeper-operator-controller -c manager -f 2>&1 | tee operator.log &
+          make test-e2e NAMESPACE=gatekeeper-system
 
-    - name: Debug
-      if: ${{ failure() }}
-      run: |
-        echo "::group:Deployments"
-        kubectl -n gatekeeper-system get all
-        echo "---"
-        kubectl -n gatekeeper-system get deployment/gatekeeper-operator-controller -o yaml
-        echo "::endgroup::"
-        echo "::group::Operator Logs"
-        cat operator.log
-        echo "::endgroup::"
+      - name: Debug
+        if: ${{ failure() }}
+        run: |
+          echo "::group:Deployments"
+          kubectl -n gatekeeper-system get all
+          echo "---"
+          kubectl -n gatekeeper-system get deployment/gatekeeper-operator-controller -o yaml
+          echo "::endgroup::"
+          echo "::group::Operator Logs"
+          cat operator.log
+          echo "::endgroup::"
 
   e2e-openshift-tests:
     name: Run e2e Openshift tests
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
-    - name: Download binaries
-      run: |
-        make download-binaries
+      - name: Download binaries
+        run: |
+          make download-binaries
 
-    - name: Create K8s KinD Cluster
-      run: |
-        make test-cluster
-        make test-openshift-setup
+      - name: Create K8s KinD Cluster
+        run: |
+          make test-cluster
+          make test-openshift-setup
 
-    - name: Build and Push Test Container Image to KIND node
-      run: |
-        make docker-build IMG=localhost:5000/gatekeeper-operator:$GITHUB_SHA
-        kind load docker-image localhost:5000/gatekeeper-operator:$GITHUB_SHA
+      - name: Build and Push Test Container Image to KIND node
+        run: |
+          make docker-build IMG=localhost:5000/gatekeeper-operator:$GITHUB_SHA
+          kind load docker-image localhost:5000/gatekeeper-operator:$GITHUB_SHA
 
-    - name: E2E Openshift Tests
-      run: |
-        make deploy-ci NAMESPACE=openshift-gatekeeper-system IMG=localhost:5000/gatekeeper-operator:$GITHUB_SHA
-        kubectl -n openshift-gatekeeper-system wait deployment/gatekeeper-operator-controller --for condition=Available --timeout=90s
-        kubectl -n openshift-gatekeeper-system logs deployment/gatekeeper-operator-controller -c manager -f  2>&1 | tee operator.log &
-        make test-e2e-openshift
+      - name: E2E Openshift Tests
+        run: |
+          make deploy-ci NAMESPACE=openshift-gatekeeper-system IMG=localhost:5000/gatekeeper-operator:$GITHUB_SHA
+          kubectl -n openshift-gatekeeper-system wait deployment/gatekeeper-operator-controller --for condition=Available --timeout=90s
+          kubectl -n openshift-gatekeeper-system logs deployment/gatekeeper-operator-controller -c manager -f  2>&1 | tee operator.log &
+          make test-e2e-openshift
 
-    - name: Debug
-      if: ${{ failure() }}
-      run: |
-        echo "::group:Deployments"
-        kubectl -n openshift-gatekeeper-system get all
-        echo "---"
-        kubectl -n openshift-gatekeeper-system get deployment/gatekeeper-operator-controller -o yaml
-        echo "::endgroup::"
-        echo "::group::Operator Logs"
-        cat operator.log
-        echo "::endgroup::"
+      - name: Debug
+        if: ${{ failure() }}
+        run: |
+          echo "::group:Deployments"
+          kubectl -n openshift-gatekeeper-system get all
+          echo "---"
+          kubectl -n openshift-gatekeeper-system get deployment/gatekeeper-operator-controller -o yaml
+          echo "::endgroup::"
+          echo "::group::Operator Logs"
+          cat operator.log
+          echo "::endgroup::"
 
   gatekeeper-e2e-tests:
     name: Run gatekeeper e2e tests
@@ -170,65 +170,65 @@ jobs:
         working-directory: gatekeeper-operator
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        path: gatekeeper-operator
+      - uses: actions/checkout@v4
+        with:
+          path: gatekeeper-operator
 
-    - uses: actions/setup-go@v5
-      with:
-        go-version-file: gatekeeper-operator/go.mod
-        cache-dependency-path: gatekeeper-operator/go.sum        
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: gatekeeper-operator/go.mod
+          cache-dependency-path: gatekeeper-operator/go.sum
 
-    - name: Download binaries
-      run: |
-        make download-binaries
+      - name: Download binaries
+        run: |
+          make download-binaries
 
-    - name: Create K8s KinD Cluster
-      run: |
-        make test-cluster
+      - name: Create K8s KinD Cluster
+        run: |
+          make test-cluster
 
-    - name: Build and Push Test Container Image to KIND node
-      run: |
-        make docker-build IMG=localhost:5000/gatekeeper-operator:$GITHUB_SHA
-        kind load docker-image localhost:5000/gatekeeper-operator:$GITHUB_SHA
+      - name: Build and Push Test Container Image to KIND node
+        run: |
+          make docker-build IMG=localhost:5000/gatekeeper-operator:$GITHUB_SHA
+          kind load docker-image localhost:5000/gatekeeper-operator:$GITHUB_SHA
 
-    - name: Set Up Environment Variables
-      run: |
-        GATEKEEPER_VERSION=v$(cat GATEKEEPER_VERSION 2>/dev/null || cat VERSION)
-        echo "GATEKEEPER_VERSION=${GATEKEEPER_VERSION}" >> ${GITHUB_ENV}
+      - name: Set Up Environment Variables
+        run: |
+          GATEKEEPER_VERSION=v$(cat GATEKEEPER_VERSION 2>/dev/null || cat VERSION)
+          echo "GATEKEEPER_VERSION=${GATEKEEPER_VERSION}" >> ${GITHUB_ENV}
 
-    - name: Deploy operator
-      env:
-        NAMESPACE: gatekeeper-system
-      run: |
-        make deploy-ci IMG=localhost:5000/gatekeeper-operator:$GITHUB_SHA
-        kubectl -n ${NAMESPACE} wait deployment/gatekeeper-operator-controller --for condition=Available --timeout=90s
-        echo "BATS_PATH=$PWD/ci-tools/bin" >> ${GITHUB_ENV}
-        make test-gatekeeper-e2e
+      - name: Deploy operator
+        env:
+          NAMESPACE: gatekeeper-system
+        run: |
+          make deploy-ci IMG=localhost:5000/gatekeeper-operator:$GITHUB_SHA
+          kubectl -n ${NAMESPACE} wait deployment/gatekeeper-operator-controller --for condition=Available --timeout=90s
+          echo "BATS_PATH=$PWD/ci-tools/bin" >> ${GITHUB_ENV}
+          make test-gatekeeper-e2e
 
-    # Checkout a local copy of Gatekeeper to use its bats e2e tests.
-    - name: Checkout Gatekeeper to verify imported manifests
-      uses: actions/checkout@v4
-      with:
-        repository: open-policy-agent/gatekeeper
-        ref: ${{ env.GATEKEEPER_VERSION }}
-        path: gatekeeper
+      # Checkout a local copy of Gatekeeper to use its bats e2e tests.
+      - name: Checkout Gatekeeper to verify imported manifests
+        uses: actions/checkout@v4
+        with:
+          repository: open-policy-agent/gatekeeper
+          ref: ${{ env.GATEKEEPER_VERSION }}
+          path: gatekeeper
 
-    - name: Gatekeeper E2E Tests
-      working-directory: gatekeeper
-      run: |
-        echo "::group::Patch Gatekeeper tests / Build and push test image"
-        export PATH=${{ env.BATS_PATH }}:$PATH
-        echo "* Patching test command for exempt namespaces:"
-        replace='num_namespaces=$(($(kubectl get ns -o json | jq '\''.items | length'\'')-$(kubectl get ns | grep excluded | wc  -l)))'
-        sed -i "s/num_namespaces=.*/$replace/" test/bats/test.bats
+      - name: Gatekeeper E2E Tests
+        working-directory: gatekeeper
+        run: |
+          echo "::group::Patch Gatekeeper tests / Build and push test image"
+          export PATH=${{ env.BATS_PATH }}:$PATH
+          echo "* Patching test command for exempt namespaces:"
+          replace='num_namespaces=$(($(kubectl get ns -o json | jq '\''.items | length'\'')-$(kubectl get ns | grep excluded | wc  -l)))'
+          sed -i "s/num_namespaces=.*/$replace/" test/bats/test.bats
 
-        echo "* Patching svc manifest NodePort (See https://github.com/open-policy-agent/gatekeeper/pull/3267):"
-        yq '.spec.type = "NodePort"' -i test/bats/tests/mutations/mutate_svc.yaml
+          echo "* Patching svc manifest NodePort (See https://github.com/open-policy-agent/gatekeeper/pull/3267):"
+          yq '.spec.type = "NodePort"' -i test/bats/tests/mutations/mutate_svc.yaml
 
-        test/externaldata/dummy-provider/scripts/generate-tls-certificate.sh
-        docker build -t dummy-provider:test -f test/externaldata/dummy-provider/Dockerfile test/externaldata/dummy-provider
-        kind load docker-image --name kind dummy-provider:test
-        echo "::endgroup::"
+          test/externaldata/dummy-provider/scripts/generate-tls-certificate.sh
+          docker build -t dummy-provider:test -f test/externaldata/dummy-provider/Dockerfile test/externaldata/dummy-provider
+          kind load docker-image --name kind dummy-provider:test
+          echo "::endgroup::"
 
-        make test-e2e GATEKEEPER_NAMESPACE=${NAMESPACE} ENABLE_MUTATION_TESTS=1
+          make test-e2e GATEKEEPER_NAMESPACE=${NAMESPACE} ENABLE_MUTATION_TESTS=1

--- a/.github/workflows/olm_tests.yaml
+++ b/.github/workflows/olm_tests.yaml
@@ -3,12 +3,12 @@ name: OLM-Tests
 on:
   push:
     branches:
-    - main
-    - release-[0-9]+.[0-9]+
+      - main
+      - release-[0-9]+.[0-9]+
   pull_request:
     branches:
-    - main
-    - release-[0-9]+.[0-9]+
+      - main
+      - release-[0-9]+.[0-9]+
 
 jobs:
   main:
@@ -16,70 +16,70 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: actions/setup-go@v5
-      with:
-        go-version-file: go.mod
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
-    - name: Download binaries
-      run: |
-        make download-binaries
+      - name: Download binaries
+        run: |
+          make download-binaries
 
-    - name: Verify bundle
-      run: |
-        make bundle
-        git diff --exit-code
+      - name: Verify bundle
+        run: |
+          make bundle
+          git diff --exit-code
 
-    - name: Create and set up K8s KinD Cluster
-      run: |
-        make test-cluster
+      - name: Create and set up K8s KinD Cluster
+        run: |
+          make test-cluster
 
-    - name: Build and Push Test Container Image and Bundle/Bundle Index Images
-      run: |
-        make build-and-push-bundle-images REPO=localhost:5000 VERSION_TAG=${GITHUB_SHA}
+      - name: Build and Push Test Container Image and Bundle/Bundle Index Images
+        run: |
+          make build-and-push-bundle-images REPO=localhost:5000 VERSION_TAG=${GITHUB_SHA}
 
-    - name: Deploy OLM
-      run: |
-        make deploy-olm
+      - name: Deploy OLM
+        run: |
+          make deploy-olm
 
-    - name: Deploy resources on KIND cluster to install Gatekeeper
-      run: |
-        make deploy-using-olm REPO=localhost:5000 VERSION_TAG=${GITHUB_SHA} NAMESPACE=mygatekeeper
-        for i in {1..9}; do
-          echo "Waiting for gatekeeper-operator-controller deployment creation (${i}/9) ..."
-          kubectl -n mygatekeeper get deployment gatekeeper-operator-controller && break
+      - name: Deploy resources on KIND cluster to install Gatekeeper
+        run: |
+          make deploy-using-olm REPO=localhost:5000 VERSION_TAG=${GITHUB_SHA} NAMESPACE=mygatekeeper
+          for i in {1..9}; do
+            echo "Waiting for gatekeeper-operator-controller deployment creation (${i}/9) ..."
+            kubectl -n mygatekeeper get deployment gatekeeper-operator-controller && break
 
-          # Patch any ErrorPreventedResolution status, which would unnecessarily block the deployment for 10 minutes
-          oc get subscription -n mygatekeeper -l operators.coreos.com/gatekeeper-operator.mygatekeeper= -o yaml |
-            yq '.items[0] | .status.conditions[] |= del(select(.reason == "ErrorPreventedResolution"))' | oc apply -f -
+            # Patch any ErrorPreventedResolution status, which would unnecessarily block the deployment for 10 minutes
+            oc get subscription -n mygatekeeper -l operators.coreos.com/gatekeeper-operator.mygatekeeper= -o yaml |
+              yq '.items[0] | .status.conditions[] |= del(select(.reason == "ErrorPreventedResolution"))' | oc apply -f -
 
-          sleep 10
-        done
-        for i in {1..6}; do
-          err_code=0
-          echo "Waiting for gatekeeper-operator-controller deployment to be available (${i}/6) ..."
-          kubectl -n mygatekeeper rollout status deployment/gatekeeper-operator-controller --timeout=30s && break || err_code=$?
-        done
-        [[ "${err_code}" == "0" ]] || { echo "Deployment failed to become available."; exit ${err_code}; }
+            sleep 10
+          done
+          for i in {1..6}; do
+            err_code=0
+            echo "Waiting for gatekeeper-operator-controller deployment to be available (${i}/6) ..."
+            kubectl -n mygatekeeper rollout status deployment/gatekeeper-operator-controller --timeout=30s && break || err_code=$?
+          done
+          [[ "${err_code}" == "0" ]] || { echo "Deployment failed to become available."; exit ${err_code}; }
 
-    - name: E2E Tests
-      run: |
-        kubectl -n mygatekeeper logs deployment/gatekeeper-operator-controller -c manager -f  2>&1 | tee operator.log &
-        make test-e2e NAMESPACE=mygatekeeper
+      - name: E2E Tests
+        run: |
+          kubectl -n mygatekeeper logs deployment/gatekeeper-operator-controller -c manager -f  2>&1 | tee operator.log &
+          make test-e2e NAMESPACE=mygatekeeper
 
-    - name: Debug
-      if: ${{ failure() }}
-      run: |
-        echo "::group:Deployments"
-        kubectl -n mygatekeeper get all
-        echo "---"
-        kubectl -n mygatekeeper get deployment/gatekeeper-operator-controller -o yaml
-        echo "::endgroup::"
-        echo "::group::Operator Logs"
-        cat operator.log
-        echo "::endgroup::"
+      - name: Debug
+        if: ${{ failure() }}
+        run: |
+          echo "::group:Deployments"
+          kubectl -n mygatekeeper get all
+          echo "---"
+          kubectl -n mygatekeeper get deployment/gatekeeper-operator-controller -o yaml
+          echo "::endgroup::"
+          echo "::group::Operator Logs"
+          cat operator.log
+          echo "::endgroup::"
 
-        echo "::group::Deployments"
-        kubectl -n mygatekeeper get deployments -o yaml
-        echo "::endgroup::"
+          echo "::group::Deployments"
+          kubectl -n mygatekeeper get deployments -o yaml
+          echo "::endgroup::"

--- a/.github/workflows/olm_tests.yaml
+++ b/.github/workflows/olm_tests.yaml
@@ -49,6 +49,11 @@ jobs:
         for i in {1..9}; do
           echo "Waiting for gatekeeper-operator-controller deployment creation (${i}/9) ..."
           kubectl -n mygatekeeper get deployment gatekeeper-operator-controller && break
+
+          # Patch any ErrorPreventedResolution status, which would unnecessarily block the deployment for 10 minutes
+          oc get subscription -n mygatekeeper -l operators.coreos.com/gatekeeper-operator.mygatekeeper= -o yaml |
+            yq '.items[0] | .status.conditions[] |= del(select(.reason == "ErrorPreventedResolution"))' | oc apply -f -
+
           sleep 10
         done
         for i in {1..6}; do

--- a/controllers/config_controller.go
+++ b/controllers/config_controller.go
@@ -65,12 +65,12 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context,
 	}, gatekeeper)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			r.Log.V(2).Info("Gatekeeper does not exist")
+			log.V(2).Info("Gatekeeper does not exist")
 
 			return reconcile.Result{}, nil
 		}
 
-		r.Log.Error(err, "Failed to get the Gatekeeper CR")
+		log.Error(err, "Failed to get the Gatekeeper CR")
 
 		return reconcile.Result{}, err
 	}
@@ -86,16 +86,16 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context,
 		if apierrors.IsNotFound(err) {
 			err = createDefaultConfig(ctx, r.Client, r.Namespace, gatekeeper, r.Scheme)
 			if err != nil {
-				r.Log.Error(err, "Failed to create the Config")
+				log.Error(err, "Failed to create the Config")
 
 				return reconcile.Result{}, err
 			}
 
-			r.Log.Info("The Config object was deleted. The Config object was recreated")
+			log.Info("The Config object was not found and has been recreated.")
 
 			return reconcile.Result{}, nil
 		} else {
-			r.Log.Error(err, "Failed to get the Config")
+			log.Error(err, "Failed to get the Config")
 
 			return reconcile.Result{}, err
 		}
@@ -103,7 +103,7 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context,
 
 	err = setExemptNamespaces(ctx, r.Client, config, gatekeeper, r.Scheme, r.Log)
 	if err != nil {
-		r.Log.V(1).Error(err, "Adding default exempt namespaces has failed")
+		log.V(1).Error(err, "Adding default exempt namespaces to the Config has failed")
 
 		return reconcile.Result{}, err
 	}

--- a/controllers/config_controller.go
+++ b/controllers/config_controller.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -40,9 +41,6 @@ func (r *ConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					newObj := e.ObjectNew.(*v1alpha1.Config)
 
 					return !reflect.DeepEqual(oldObj.Spec.Match, newObj.Spec.Match)
-				},
-				CreateFunc: func(ce event.CreateEvent) bool {
-					return false
 				},
 			},
 			)).
@@ -101,7 +99,7 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context,
 		}
 	}
 
-	err = setExemptNamespaces(ctx, r.Client, config, gatekeeper, r.Scheme, r.Log)
+	err = r.setExemptNamespaces(ctx, config, gatekeeper)
 	if err != nil {
 		log.V(1).Error(err, "Adding default exempt namespaces to the Config has failed")
 
@@ -109,4 +107,72 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context,
 	}
 
 	return reconcile.Result{}, nil
+}
+
+// Reset Config.Spec.Match and append the default exempt namespaces and
+// provided matches from the Gatekeeper CR
+func (r *ConfigReconciler) setExemptNamespaces(
+	ctx context.Context,
+	existingConfig *v1alpha1.Config,
+	gatekeeper *operatorv1alpha1.Gatekeeper,
+) error {
+	// Find OwnerReference
+	ownerRefFound := false
+
+	for _, ownerRef := range existingConfig.GetOwnerReferences() {
+		if ownerRef.UID == gatekeeper.UID {
+			ownerRefFound = true
+
+			break
+		}
+	}
+
+	// The ownerRefFound which is false means the Config resource was not created by gatekeeper-operator
+	if !ownerRefFound && len(existingConfig.Spec.Match) != 0 {
+		r.Log.V(1).Info("The gatekeeper matches already exist. Skip adding DefaultExemptNamespaces")
+
+		return nil
+	}
+
+	// Reset Config Match
+	var newMatch []v1alpha1.MatchEntry
+
+	var configDefault *v1alpha1.Config
+
+	// When it is DisableDefaultMatches = false or nil then append default exempt namespaces
+	if gatekeeper.Spec.Config == nil || !gatekeeper.Spec.Config.DisableDefaultMatches {
+		configDefault = getDefaultConfig("")
+		newMatch = append(newMatch, configDefault.Spec.Match...)
+	}
+
+	// Avoid gatekeeper.Spec.Config nil error
+	if gatekeeper.Spec.Config != nil {
+		// Append matched from Gatekeeper CR spec.config.matches
+		newMatch = append(newMatch, gatekeeper.Spec.Config.Matches...)
+	}
+
+	// When ownerRefFound is false, config will be updated for adding ownerRef
+	if reflect.DeepEqual(existingConfig.Spec.Match, newMatch) && ownerRefFound {
+		r.Log.V(1).Info("No need to Update")
+
+		return nil
+	}
+
+	existingConfig.Spec.Match = newMatch
+
+	// Set OwnerReference
+	if !ownerRefFound {
+		if err := controllerutil.SetOwnerReference(gatekeeper, existingConfig, r.Scheme); err != nil {
+			return err
+		}
+	}
+
+	err := r.Update(ctx, existingConfig, &client.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	r.Log.Info("Updated Config object with excluded namespaces")
+
+	return nil
 }

--- a/controllers/config_helper_test.go
+++ b/controllers/config_helper_test.go
@@ -9,18 +9,18 @@ import (
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	operatorv1alpha1 "github.com/gatekeeper/gatekeeper-operator/api/v1alpha1"
 )
 
 func TestAddDefaultExemptNamespaces(t *testing.T) {
-	scheme := runtime.NewScheme()
+	reconciler := ConfigReconciler{
+		Scheme: runtime.NewScheme(),
+		Client: fake.NewClientBuilder().Build(),
+	}
 	g := NewWithT(t)
 	ctx := context.TODO()
-	c := fake.NewClientBuilder().Build()
-	Log := ctrl.Log.WithName("controllers").WithName("Gatekeeper")
 
 	config := &v1alpha1.Config{
 		ObjectMeta: metav1.ObjectMeta{
@@ -69,7 +69,7 @@ func TestAddDefaultExemptNamespaces(t *testing.T) {
 				},
 			}
 
-			_ = setExemptNamespaces(ctx, c, config, gatekeeper, scheme, Log)
+			_ = reconciler.setExemptNamespaces(ctx, config, gatekeeper)
 			g.Expect(config.Spec.Match).Should(HaveLen(1))
 			g.Expect(config.Spec.Match).Should(BeComparableTo(defaultConfig.Spec.Match))
 		})
@@ -82,7 +82,7 @@ func TestAddDefaultExemptNamespaces(t *testing.T) {
 			Spec: operatorv1alpha1.GatekeeperSpec{},
 		}
 
-		_ = setExemptNamespaces(ctx, c, config, gatekeeper, scheme, Log)
+		_ = reconciler.setExemptNamespaces(ctx, config, gatekeeper)
 		g.Expect(config.Spec.Match).Should(HaveLen(1))
 		g.Expect(config.Spec.Match).Should(BeComparableTo(defaultConfig.Spec.Match))
 	})
@@ -118,7 +118,7 @@ func TestAddDefaultExemptNamespaces(t *testing.T) {
 			},
 		}
 
-		_ = setExemptNamespaces(ctx, c, config, gatekeeper, scheme, Log)
+		_ = reconciler.setExemptNamespaces(ctx, config, gatekeeper)
 		g.Expect(config.Spec.Match).Should(HaveLen(2))
 		g.Expect(config.Spec.Match[0]).Should(BeComparableTo(defaultConfig.Spec.Match[0]))
 		g.Expect(config.Spec.Match[1]).Should(BeComparableTo(gatekeeper.Spec.Config.Matches[0]))
@@ -153,7 +153,7 @@ func TestAddDefaultExemptNamespaces(t *testing.T) {
 			},
 		}
 
-		_ = setExemptNamespaces(ctx, c, config, gatekeeper, scheme, Log)
+		_ = reconciler.setExemptNamespaces(ctx, config, gatekeeper)
 		g.Expect(config.Spec.Match).Should(Equal(gatekeeper.Spec.Config.Matches))
 	})
 
@@ -184,7 +184,7 @@ func TestAddDefaultExemptNamespaces(t *testing.T) {
 			},
 		}
 
-		_ = setExemptNamespaces(ctx, c, config, gatekeeper, scheme, Log)
+		_ = reconciler.setExemptNamespaces(ctx, config, gatekeeper)
 		g.Expect(config.Spec.Match).Should(HaveLen(2))
 		g.Expect(config.Spec.Match[0]).Should(BeComparableTo(defaultConfig.Spec.Match[0]))
 		g.Expect(config.Spec.Match[1]).Should(BeComparableTo(gatekeeper.Spec.Config.Matches[0]))
@@ -220,13 +220,13 @@ func TestAddDefaultExemptNamespaces(t *testing.T) {
 			},
 		}
 		// First try
-		_ = setExemptNamespaces(ctx, c, config, gatekeeper, scheme, Log)
+		_ = reconciler.setExemptNamespaces(ctx, config, gatekeeper)
 
 		// Second try
-		_ = setExemptNamespaces(ctx, c, config, gatekeeper, scheme, Log)
+		_ = reconciler.setExemptNamespaces(ctx, config, gatekeeper)
 
 		// Third try
-		_ = setExemptNamespaces(ctx, c, config, gatekeeper, scheme, Log)
+		_ = reconciler.setExemptNamespaces(ctx, config, gatekeeper)
 		g.Expect(config.Spec.Match).Should(HaveLen(2))
 		g.Expect(config.Spec.Match[0]).Should(BeComparableTo(defaultConfig.Spec.Match[0]))
 		g.Expect(config.Spec.Match[1]).Should(BeComparableTo(gatekeeper.Spec.Config.Matches[0]))
@@ -270,7 +270,7 @@ func TestAddDefaultExemptNamespaces(t *testing.T) {
 			},
 		}
 
-		_ = setExemptNamespaces(ctx, c, config, gatekeeper, scheme, Log)
+		_ = reconciler.setExemptNamespaces(ctx, config, gatekeeper)
 
 		g.Expect(config.Spec.Match).Should(HaveLen(1))
 		g.Expect(config.Spec.Match[0]).Should(BeComparableTo(config.Spec.Match[0]))

--- a/controllers/constraintstatus_controller.go
+++ b/controllers/constraintstatus_controller.go
@@ -92,7 +92,7 @@ func (r *ConstraintPodStatusReconciler) Reconcile(ctx context.Context,
 	}, gatekeeper)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Error(err, "Gatekeeper resource is not found")
+			log.Info("Gatekeeper resource is not found: " + err.Error())
 
 			return reconcile.Result{}, nil
 		}

--- a/controllers/constraintstatus_controller.go
+++ b/controllers/constraintstatus_controller.go
@@ -135,7 +135,7 @@ func (r *ConstraintPodStatusReconciler) Reconcile(ctx context.Context,
 		return reconcile.Result{}, err
 	}
 
-	constraint, constraintName, err := getConstraint(ctx, *constraintPodStatus, r.DynamicClient)
+	constraint, constraintName, err := getConstraint(ctx, constraintPodStatus.GetLabels(), r.DynamicClient)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			r.Log.Info("The Constraint was not found", "constraintName:", constraintName)

--- a/controllers/discovery_storage.go
+++ b/controllers/discovery_storage.go
@@ -48,7 +48,7 @@ func (r *DiscoveryStorage) getSyncOnlys(constraintMatchKinds []interface{}) (
 			for _, kind := range kindsInKinds {
 				version, err := r.getAPIVersion(kind.(string), apiGroup.(string), false)
 				if err != nil {
-					r.Log.V(1).Info("getAPIVersion has error but continue")
+					r.Log.V(1).Info(fmt.Sprintf("getAPIVersion has an error. Continuing anyway: %s", err.Error()))
 
 					if finalErr == nil {
 						finalErr = err

--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -87,7 +87,6 @@ const (
 	AdmissionEventsInvolvedNamespaceArg = "--admission-events-involved-namespace"
 	AuditEventsInvolvedNamespaceArg     = "--audit-events-involved-namespace"
 	ExemptNamespaceArg                  = "--exempt-namespace"
-	EnableMutationArg                   = "--enable-mutation"
 	OperationArg                        = "--operation"
 	OperationMutationStatus             = "mutation-status"
 	OperationMutationWebhook            = "mutation-webhook"

--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -227,8 +227,12 @@ func (r *GatekeeperReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				r.StopCPSController()
 			}
 
+			logger.Info("The Gatekeeper resource is not found.")
+
 			return ctrl.Result{}, nil
 		}
+
+		logger.Error(err, "Failed to get Gatekeeper resource. Requeuing.")
 
 		return ctrl.Result{}, err
 	}
@@ -267,7 +271,7 @@ func (r *GatekeeperReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	err = r.initConfig(ctx, gatekeeper)
 	if err != nil {
-		r.Log.Error(err, "Fail to set the default Config")
+		logger.Error(err, "Fail to set the default Config")
 
 		return ctrl.Result{}, err
 	}

--- a/controllers/gatekeeper_controller_test.go
+++ b/controllers/gatekeeper_controller_test.go
@@ -1287,7 +1287,7 @@ func TestMutationArg(t *testing.T) {
 	webhookObj, err := util.GetManifestObject(WebhookFile)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(webhookObj).ToNot(BeNil())
-	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(EnableMutationArg))
+	expectObjContainerArg(g, webhookObj).To(HaveKeyWithValue(OperationArg, OperationMutationWebhook))
 
 	auditObj, err := util.GetManifestObject(AuditFile)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -1296,7 +1296,7 @@ func TestMutationArg(t *testing.T) {
 	// test nil
 	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
-	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(EnableMutationArg))
+	expectObjContainerArg(g, webhookObj).To(HaveKeyWithValue(OperationArg, OperationMutationWebhook))
 
 	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -1306,7 +1306,7 @@ func TestMutationArg(t *testing.T) {
 	gatekeeper.Spec.MutatingWebhook = &mutation
 	err = crOverrides(gatekeeper, WebhookFile, webhookObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
-	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(EnableMutationArg))
+	expectObjContainerArg(g, webhookObj).NotTo(HaveKeyWithValue(OperationArg, OperationMutationWebhook))
 
 	err = crOverrides(gatekeeper, AuditFile, auditObj, namespace, false, false)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -1380,7 +1380,6 @@ func TestAllWebhookArgs(t *testing.T) {
 	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(EmitAdmissionEventsArg))
 	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(AdmissionEventsInvolvedNamespaceArg))
 	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(LogLevelArg))
-	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(EnableMutationArg))
 	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(LogMutationsArg))
 	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(MutationAnnotationsArg))
 	// test nil
@@ -1389,7 +1388,6 @@ func TestAllWebhookArgs(t *testing.T) {
 	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(EmitAdmissionEventsArg))
 	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(AdmissionEventsInvolvedNamespaceArg))
 	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(LogLevelArg))
-	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(EnableMutationArg))
 	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(LogMutationsArg))
 	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(MutationAnnotationsArg))
 	// test override without mutation
@@ -1399,7 +1397,6 @@ func TestAllWebhookArgs(t *testing.T) {
 	expectObjContainerArg(g, webhookObj).To(HaveKeyWithValue(EmitAdmissionEventsArg, "true"))
 	expectObjContainerArg(g, webhookObj).To(HaveKeyWithValue(AdmissionEventsInvolvedNamespaceArg, "true"))
 	expectObjContainerArg(g, webhookObj).To(HaveKeyWithValue(LogLevelArg, "DEBUG"))
-	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(EnableMutationArg))
 	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(LogMutationsArg))
 	expectObjContainerArg(g, webhookObj).NotTo(HaveKey(MutationAnnotationsArg))
 	// test override with mutation

--- a/main.go
+++ b/main.go
@@ -137,26 +137,26 @@ func main() {
 			ClientSet: kubernetes.NewForConfigOrDie(mgr.GetConfig()),
 		},
 	}).SetupWithManager(mgr, fromCPSMgrSource); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Gatekeeper")
+		setupLog.Error(err, "Unable to create controller", "controller", "Gatekeeper")
 		os.Exit(1)
 	}
 
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
+		setupLog.Error(err, "Unable to set up health check")
 		os.Exit(1)
 	}
 
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
+		setupLog.Error(err, "Unable to set up ready check")
 		os.Exit(1)
 	}
 
-	setupLog.Info("starting manager")
+	setupLog.Info("Starting manager")
 
 	if err := mgr.Start(ctx); err != nil {
-		setupLog.Error(err, "problem running manager")
+		setupLog.Error(err, "Problem running manager")
 
 		os.Exit(1)
 	}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -15,6 +15,8 @@ limitations under the License.
 package platform
 
 import (
+	"fmt"
+
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -76,7 +78,7 @@ func (k8SBasedPlatformVersioner) defaultArgs(
 func (pv k8SBasedPlatformVersioner) getPlatformInfo(
 	client discovery.DiscoveryInterface, cfg *rest.Config,
 ) (PlatformInfo, error) {
-	log.Info("detecting platform version...")
+	log.Info("Detecting platform version...")
 
 	info := PlatformInfo{Name: Kubernetes}
 
@@ -84,16 +86,12 @@ func (pv k8SBasedPlatformVersioner) getPlatformInfo(
 
 	client, err = pv.defaultArgs(client, cfg)
 	if err != nil {
-		log.Info("issue occurred while defaulting client/cfg args")
-
-		return info, err
+		return info, fmt.Errorf("failed to default k8s client/config args: %w", err)
 	}
 
 	k8sVersion, err := client.ServerVersion()
 	if err != nil {
-		log.Info("issue occurred while fetching ServerVersion")
-
-		return info, err
+		return info, fmt.Errorf("failed to fetch ServerVersion: %w", err)
 	}
 
 	info.K8SVersion = k8sVersion.Major + "." + k8sVersion.Minor
@@ -101,9 +99,7 @@ func (pv k8SBasedPlatformVersioner) getPlatformInfo(
 
 	apiList, err := client.ServerGroups()
 	if err != nil {
-		log.Info("issue occurred while fetching ServerGroups")
-
-		return info, err
+		return info, fmt.Errorf("failed to fetch ServerGroups: %w", err)
 	}
 
 	for _, v := range apiList.Groups {

--- a/test/e2e/gatekeeper_controller_test.go
+++ b/test/e2e/gatekeeper_controller_test.go
@@ -952,19 +952,6 @@ func byCheckingValidationEnabled(ctx SpecContext) {
 type getCRDFunc func(types.NamespacedName, *extv1.CustomResourceDefinition)
 
 func byCheckingMutationEnabled(ctx SpecContext, auditDeployment, webhookDeployment *appsv1.Deployment) {
-	By(fmt.Sprintf("Checking %s argument is set", controllers.EnableMutationArg), func() {
-		Eventually(func() bool {
-			webhookDeployment = gatekeeperWebhookDeployment(ctx)
-			_, found := getContainerArg(
-				webhookDeployment.Spec.Template.Spec.Containers[0].Args,
-				controllers.EnableMutationArg,
-			)
-
-			return found
-		}, timeout, pollInterval).Should(BeTrue(),
-			fmt.Sprintf("Argument %s should be set", controllers.EnableMutationArg))
-	})
-
 	By(fmt.Sprintf(
 		"Checking %s=%s argument is set", controllers.OperationArg, controllers.OperationMutationWebhook,
 	), func() {
@@ -1012,19 +999,6 @@ func byCheckingValidationDisabled(ctx SpecContext) {
 }
 
 func byCheckingMutationDisabled(ctx SpecContext, auditDeployment, webhookDeployment *appsv1.Deployment) {
-	By(fmt.Sprintf("Checking %s argument is not set", controllers.EnableMutationArg), func() {
-		Eventually(func() bool {
-			webhookDeployment = gatekeeperWebhookDeployment(ctx)
-			_, found := getContainerArg(
-				webhookDeployment.Spec.Template.Spec.Containers[0].Args,
-				controllers.EnableMutationArg,
-			)
-
-			return found
-		}, timeout, pollInterval).Should(BeFalse(),
-			fmt.Sprintf("Argument %s should not be set", controllers.EnableMutationArg))
-	})
-
 	By(fmt.Sprintf(
 		"Checking %s=%s argument is not set", controllers.OperationArg, controllers.OperationMutationWebhook,
 	), func() {

--- a/test/resources/case1_audit_from_cache/constraint-wrong.yaml
+++ b/test/resources/case1_audit_from_cache/constraint-wrong.yaml
@@ -1,7 +1,7 @@
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: Case1Template
 metadata:
-  name: case1-worng
+  name: case1-wrong
 spec:
   match:
     kinds:


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/ACM-11999

- Removes checks for the `--enable-mutation` flag, which has been deprecated since v3.7 and no longer has any effect if it's provided: https://github.com/open-policy-agent/gatekeeper/commit/c36e3d8fbdebe2b28eda0c554b2801f4bd6c4dd7
- Adds a patch in the OLM workflow to remove any `ErrorPreventedResolution` in the Subscription status caused by the OLM OperatorHubio catalog being unavailable
- Tweak logging messages
- Shuts down the Config reconciler and uses the DynamicClient to prevent it from spamming the logs when Gatekeeper is deleted
- Adds a 30s wait to the Config test since the initial update didn't always get picked up while the controller is starting
- Refactors the E2E tests to have a unified webhook check that accepts an enabled/disabled argument and handles it accordingly.