### PR TITLE
Disable leader election on the "sub" controllers

### DIFF
--- a/controllers/config_helper.go
+++ b/controllers/config_helper.go
@@ -137,8 +137,7 @@ func (r *GatekeeperReconciler) handleConfigController(ctx context.Context) error
 		Metrics: server.Options{
 			BindAddress: "0",
 		},
-		LeaderElection:   r.EnableLeaderElection,
-		LeaderElectionID: "5ff985ccc.config.gatekeeper.sh",
+		LeaderElection: false,
 		Cache: cacheRuntime.Options{
 			ByObject: map[client.Object]cacheRuntime.ByObject{
 				&v1alpha1.Config{}: {

--- a/controllers/cps_controller_helper.go
+++ b/controllers/cps_controller_helper.go
@@ -62,8 +62,7 @@ func (r *GatekeeperReconciler) handleCPSController(ctx context.Context,
 		Metrics: server.Options{
 			BindAddress: "0",
 		},
-		LeaderElection:   r.EnableLeaderElection,
-		LeaderElectionID: "5ff985ccc.constraintstatuspod.gatekeeper.sh",
+		LeaderElection: false,
 		Cache: cacheRuntime.Options{
 			ByObject: map[client.Object]cacheRuntime.ByObject{
 				&gkv1beta1.ConstraintPodStatus{}: {


### PR DESCRIPTION
Leader election is not needed on the "sub" controllers since they can only start when the main controller is the leader. This should help with the test failures.