### PR TITLE
Rename the module to the Stolostron organization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ ifeq ($(DIFF), 1)
   GIT_TREESTATE = "dirty"
 endif
 
-VERSION_PKG = "github.com/gatekeeper/gatekeeper-operator/pkg/version"
+VERSION_PKG = "github.com/stolostron/gatekeeper-operator/pkg/version"
 LDFLAGS = "-X $(VERSION_PKG).gitVersion=$(GIT_VERSION) \
            -X $(VERSION_PKG).gitCommit=$(GIT_HASH) \
            -X $(VERSION_PKG).gitTreeState=$(GIT_TREESTATE) \

--- a/PROJECT
+++ b/PROJECT
@@ -5,7 +5,7 @@ plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
 projectName: gatekeeper-operator
-repo: github.com/gatekeeper/gatekeeper-operator
+repo: github.com/stolostron/gatekeeper-operator
 resources:
 - api:
     crdVersion: v1
@@ -13,6 +13,6 @@ resources:
   domain: gatekeeper.sh
   group: operator
   kind: Gatekeeper
-  path: github.com/gatekeeper/gatekeeper-operator/api/v1alpha1
+  path: github.com/stolostron/gatekeeper-operator/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # OPA Gatekeeper Operator
-[![CI-Tests](https://github.com/gatekeeper/gatekeeper-operator/actions/workflows/ci_tests.yaml/badge.svg)](https://github.com/gatekeeper/gatekeeper-operator/actions/workflows/ci_tests.yaml)
-[![OLM-Tests](https://github.com/gatekeeper/gatekeeper-operator/actions/workflows/olm_tests.yaml/badge.svg)](https://github.com/gatekeeper/gatekeeper-operator/actions/workflows/olm_tests.yaml)
-[![Create Release](https://github.com/gatekeeper/gatekeeper-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/gatekeeper/gatekeeper-operator/actions/workflows/release.yaml)
-[![Image](https://github.com/gatekeeper/gatekeeper-operator/actions/workflows/image.yaml/badge.svg)](https://github.com/gatekeeper/gatekeeper-operator/actions/workflows/image.yaml)
-[![Docker Repository on Quay](https://img.shields.io/:Image-Quay-blue.svg)](https://quay.io/repository/gatekeeper/gatekeeper-operator)
+[![CI-Tests](https://github.com/stolostron/gatekeeper-operator/actions/workflows/ci_tests.yaml/badge.svg)](https://github.com/stolostron/gatekeeper-operator/actions/workflows/ci_tests.yaml)
+[![OLM-Tests](https://github.com/stolostron/gatekeeper-operator/actions/workflows/olm_tests.yaml/badge.svg)](https://github.com/stolostron/gatekeeper-operator/actions/workflows/olm_tests.yaml)
+[![Create Release](https://github.com/stolostron/gatekeeper-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/stolostron/gatekeeper-operator/actions/workflows/release.yaml)
+[![Image](https://github.com/stolostron/gatekeeper-operator/actions/workflows/image.yaml/badge.svg)](https://github.com/stolostron/gatekeeper-operator/actions/workflows/image.yaml)
+[![Docker Repository on Quay](https://img.shields.io/:Image-Quay-blue.svg)](https://quay.io/repository/stolostron/gatekeeper-operator)
 
 Operator for OPA Gatekeeper
 
@@ -101,7 +101,7 @@ If you would like to deploy Operator using OLM, you'll need to build and push th
     spec:
       displayName: Gatekeeper Operator Upstream
       image: <index image name>
-      publisher: github.com/gatekeeper/gatekeeper-operator
+      publisher: github.com/stolostron/gatekeeper-operator
       sourceType: grpc
     ---
     apiVersion: operators.coreos.com/v1

--- a/build/common/config/.golangci.yml
+++ b/build/common/config/.golangci.yml
@@ -80,7 +80,7 @@ linters-settings:
     check-shadowing: false
   gci:
      sections:
-      - prefix(github.com/gatekeeper/gatekeeper-operator)
+      - prefix(github.com/stolostron/gatekeeper-operator)
   golint:
     # minimal confidence for issues, default is 0.8
     min-confidence: 0.0

--- a/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/gatekeeper-operator.clusterserviceversion.yaml
@@ -123,7 +123,7 @@ spec:
     [#opa-gatekeeper](https://openpolicyagent.slack.com/archives/CDTN970AX).
 
     Please report issues on the respective GitHub repositories for either
-    the [Gatekeeper Operator](https://github.com/gatekeeper/gatekeeper-operator/issues) or
+    the [Gatekeeper Operator](https://github.com/stolostron/gatekeeper-operator/issues) or
     [Gatekeeper](https://github.com/open-policy-agent/gatekeeper/issues) itself.
   displayName: Gatekeeper Operator
   icon:
@@ -528,7 +528,7 @@ spec:
   - Gatekeeper
   links:
   - name: Gatekeeper Operator
-    url: https://github.com/gatekeeper/gatekeeper-operator
+    url: https://github.com/stolostron/gatekeeper-operator
   maintainers:
   - email: acm-contact@redhat.com
     name: acm-contact

--- a/config/manifests/bases/gatekeeper-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/gatekeeper-operator.clusterserviceversion.yaml
@@ -111,7 +111,7 @@ spec:
     [#opa-gatekeeper](https://openpolicyagent.slack.com/archives/CDTN970AX).
 
     Please report issues on the respective GitHub repositories for either
-    the [Gatekeeper Operator](https://github.com/gatekeeper/gatekeeper-operator/issues) or
+    the [Gatekeeper Operator](https://github.com/stolostron/gatekeeper-operator/issues) or
     [Gatekeeper](https://github.com/open-policy-agent/gatekeeper/issues) itself.
   displayName: Gatekeeper Operator
   icon:
@@ -134,7 +134,7 @@ spec:
   - Gatekeeper
   links:
   - name: Gatekeeper Operator
-    url: https://github.com/gatekeeper/gatekeeper-operator
+    url: https://github.com/stolostron/gatekeeper-operator
   maintainers:
   - email: acm-contact@redhat.com
     name: acm-contact

--- a/config/olm-install/install-resources.yaml
+++ b/config/olm-install/install-resources.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   displayName: Gatekeeper Operator Upstream
   image: quay.io/gatekeeper/gatekeeper-operator-bundle-index:latest
-  publisher: github.com/gatekeeper/gatekeeper-operator
+  publisher: github.com/stolostron/gatekeeper-operator
   sourceType: grpc
 ---
 apiVersion: operators.coreos.com/v1

--- a/controllers/config_controller.go
+++ b/controllers/config_controller.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	operatorv1alpha1 "github.com/gatekeeper/gatekeeper-operator/api/v1alpha1"
+	operatorv1alpha1 "github.com/stolostron/gatekeeper-operator/api/v1alpha1"
 )
 
 type ConfigReconciler struct {

--- a/controllers/config_helper.go
+++ b/controllers/config_helper.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	operatorv1alpha1 "github.com/gatekeeper/gatekeeper-operator/api/v1alpha1"
+	operatorv1alpha1 "github.com/stolostron/gatekeeper-operator/api/v1alpha1"
 )
 
 // Default config data

--- a/controllers/config_helper_test.go
+++ b/controllers/config_helper_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	operatorv1alpha1 "github.com/gatekeeper/gatekeeper-operator/api/v1alpha1"
+	operatorv1alpha1 "github.com/stolostron/gatekeeper-operator/api/v1alpha1"
 )
 
 func TestAddDefaultExemptNamespaces(t *testing.T) {

--- a/controllers/constraintstatus_controller.go
+++ b/controllers/constraintstatus_controller.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	operatorv1alpha1 "github.com/gatekeeper/gatekeeper-operator/api/v1alpha1"
+	operatorv1alpha1 "github.com/stolostron/gatekeeper-operator/api/v1alpha1"
 )
 
 var ControllerName = "constraintstatus_reconciler"

--- a/controllers/cps_controller_helper.go
+++ b/controllers/cps_controller_helper.go
@@ -18,8 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	"github.com/gatekeeper/gatekeeper-operator/api/v1alpha1"
-	operatorv1alpha1 "github.com/gatekeeper/gatekeeper-operator/api/v1alpha1"
+	operatorv1alpha1 "github.com/stolostron/gatekeeper-operator/api/v1alpha1"
 )
 
 var setupLog = ctrl.Log.WithName("setup")
@@ -131,7 +130,7 @@ func (r *GatekeeperReconciler) handleCPSController(ctx context.Context,
 		r.ManualReconcileTrigger <- event.GenericEvent{
 			Object: &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"apiVersion": v1alpha1.GroupVersion.String(),
+					"apiVersion": operatorv1alpha1.GroupVersion.String(),
 					"kind":       "Gatekeeper",
 					"metadata": map[string]interface{}{
 						"name": defaultGatekeeperCrName,

--- a/controllers/gatekeeper_controller.go
+++ b/controllers/gatekeeper_controller.go
@@ -45,10 +45,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	operatorv1alpha1 "github.com/gatekeeper/gatekeeper-operator/api/v1alpha1"
-	"github.com/gatekeeper/gatekeeper-operator/controllers/merge"
-	"github.com/gatekeeper/gatekeeper-operator/pkg/platform"
-	"github.com/gatekeeper/gatekeeper-operator/pkg/util"
+	operatorv1alpha1 "github.com/stolostron/gatekeeper-operator/api/v1alpha1"
+	"github.com/stolostron/gatekeeper-operator/controllers/merge"
+	"github.com/stolostron/gatekeeper-operator/pkg/platform"
+	"github.com/stolostron/gatekeeper-operator/pkg/util"
 )
 
 const (

--- a/controllers/gatekeeper_controller_test.go
+++ b/controllers/gatekeeper_controller_test.go
@@ -26,9 +26,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	operatorv1alpha1 "github.com/gatekeeper/gatekeeper-operator/api/v1alpha1"
-	"github.com/gatekeeper/gatekeeper-operator/pkg/util"
-	test "github.com/gatekeeper/gatekeeper-operator/test/e2e/util"
+	operatorv1alpha1 "github.com/stolostron/gatekeeper-operator/api/v1alpha1"
+	"github.com/stolostron/gatekeeper-operator/pkg/util"
+	test "github.com/stolostron/gatekeeper-operator/test/e2e/util"
 )
 
 var namespace = "gatekeeper-system"

--- a/controllers/merge/merge.go
+++ b/controllers/merge/merge.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/gatekeeper/gatekeeper-operator/pkg/util"
+	"github.com/stolostron/gatekeeper-operator/pkg/util"
 )
 
 // RetainClusterObjectFields updates the desired object with values retained

--- a/controllers/merge/merge_test.go
+++ b/controllers/merge/merge_test.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/gatekeeper/gatekeeper-operator/pkg/util"
+	"github.com/stolostron/gatekeeper-operator/pkg/util"
 )
 
 func TestRetainWebhookConfigurationFields(t *testing.T) {

--- a/docs/upgrading-operator-sdk.md
+++ b/docs/upgrading-operator-sdk.md
@@ -45,7 +45,7 @@ same original command that was used for this operator as shown below:
 # Execute from the root of this repository
 mkdir ../gatekeeper-operator-sdk-${OPERATOR_SDK_VERSION//./-}
 cd ../gatekeeper-operator-sdk-${OPERATOR_SDK_VERSION//./-}
-operator-sdk init --domain=gatekeeper.sh --repo=github.com/gatekeeper/gatekeeper-operator
+operator-sdk init --domain=gatekeeper.sh --repo=github.com/stolostron/gatekeeper-operator
 ```
 
 Feel free to examine the generated source files to assess differences and see

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gatekeeper/gatekeeper-operator
+module github.com/stolostron/gatekeeper-operator
 
 go 1.22.0
 

--- a/main.go
+++ b/main.go
@@ -40,11 +40,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	operatorv1alpha1 "github.com/gatekeeper/gatekeeper-operator/api/v1alpha1"
-	"github.com/gatekeeper/gatekeeper-operator/controllers"
-	"github.com/gatekeeper/gatekeeper-operator/pkg/platform"
-	"github.com/gatekeeper/gatekeeper-operator/pkg/util"
-	"github.com/gatekeeper/gatekeeper-operator/pkg/version"
+	operatorv1alpha1 "github.com/stolostron/gatekeeper-operator/api/v1alpha1"
+	"github.com/stolostron/gatekeeper-operator/controllers"
+	"github.com/stolostron/gatekeeper-operator/pkg/platform"
+	"github.com/stolostron/gatekeeper-operator/pkg/util"
+	"github.com/stolostron/gatekeeper-operator/pkg/version"
 )
 
 var (

--- a/pkg/util/namespace.go
+++ b/pkg/util/namespace.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/gatekeeper/gatekeeper-operator/pkg/platform"
+	"github.com/stolostron/gatekeeper-operator/pkg/platform"
 )
 
 var (

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 
-	"github.com/gatekeeper/gatekeeper-operator/pkg/bindata"
+	"github.com/stolostron/gatekeeper-operator/pkg/bindata"
 )
 
 var staticAssetsDir = "config/gatekeeper-rendered/"

--- a/test/e2e/case1_audit_from_cache_test.go
+++ b/test/e2e/case1_audit_from_cache_test.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
-	gv1alpha1 "github.com/gatekeeper/gatekeeper-operator/api/v1alpha1"
-	. "github.com/gatekeeper/gatekeeper-operator/test/e2e/util"
+	gv1alpha1 "github.com/stolostron/gatekeeper-operator/api/v1alpha1"
+	. "github.com/stolostron/gatekeeper-operator/test/e2e/util"
 )
 
 var _ = Describe("Test auditFromCache", Ordered, func() {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -42,8 +42,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	operatorv1alpha1 "github.com/gatekeeper/gatekeeper-operator/api/v1alpha1"
-	test "github.com/gatekeeper/gatekeeper-operator/test/e2e/util"
+	operatorv1alpha1 "github.com/stolostron/gatekeeper-operator/api/v1alpha1"
+	test "github.com/stolostron/gatekeeper-operator/test/e2e/util"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/test/e2e/gatekeeper_controller_test.go
+++ b/test/e2e/gatekeeper_controller_test.go
@@ -38,10 +38,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
-	"github.com/gatekeeper/gatekeeper-operator/api/v1alpha1"
-	"github.com/gatekeeper/gatekeeper-operator/controllers"
-	"github.com/gatekeeper/gatekeeper-operator/pkg/util"
-	test "github.com/gatekeeper/gatekeeper-operator/test/e2e/util"
+	"github.com/stolostron/gatekeeper-operator/api/v1alpha1"
+	"github.com/stolostron/gatekeeper-operator/controllers"
+	"github.com/stolostron/gatekeeper-operator/pkg/util"
+	test "github.com/stolostron/gatekeeper-operator/test/e2e/util"
 )
 
 var _ = Describe("Gatekeeper", func() {

--- a/test/e2e/options.go
+++ b/test/e2e/options.go
@@ -20,7 +20,7 @@ import (
 	"flag"
 	"time"
 
-	"github.com/gatekeeper/gatekeeper-operator/pkg/util"
+	"github.com/stolostron/gatekeeper-operator/pkg/util"
 )
 
 var (


### PR DESCRIPTION
The github.com/gatekeeper/gatekeeper-operator repo is archived. This upstream is now solely in the Stolostron GitHub organization.