### PR TITLE
Replace `oc` => `kubectl`

### DIFF
--- a/.github/workflows/olm_tests.yaml
+++ b/.github/workflows/olm_tests.yaml
@@ -51,8 +51,8 @@ jobs:
             kubectl -n mygatekeeper get deployment gatekeeper-operator-controller && break
 
             # Patch any ErrorPreventedResolution status, which would unnecessarily block the deployment for 10 minutes
-            oc get subscription -n mygatekeeper -l operators.coreos.com/gatekeeper-operator.mygatekeeper= -o yaml |
-              yq '.items[0] | .status.conditions[] |= del(select(.reason == "ErrorPreventedResolution"))' | oc apply -f - || true
+            kubectl get subscription -n mygatekeeper -l operators.coreos.com/gatekeeper-operator.mygatekeeper= -o yaml |
+              yq '.items[0] | .status.conditions[] |= del(select(.reason == "ErrorPreventedResolution"))' | kubectl apply -f - || true
 
             sleep 10
           done

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240528025155-186aa0362fba // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/imdario/mergo v1.0.0 // indirect
+	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
@@ -84,5 +84,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16 // Replaced so that 'go get -u' works. Remove/bump when upgrading.


### PR DESCRIPTION
`oc` was removed from the latest Ubuntu release.