### PR TITLE
Conditionally build Konflux images

### DIFF
--- a/.tekton/gatekeeper-operator-3-17-pull-request.yaml
+++ b/.tekton/gatekeeper-operator-3-17-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-3.17"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-3.17" && (".tekton/gatekeeper-operator-[!b]*.yaml".pathChanged() ||  "build/Dockerfile*".pathChanged() || "go.(mod|sum)".pathChanged() ||  "main.go".pathChanged() || "(api|pkg|controllers)/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: gatekeeper-operator-3-17

--- a/.tekton/gatekeeper-operator-3-17-push.yaml
+++ b/.tekton/gatekeeper-operator-3-17-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "build/konflux-patch.sh"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-3.17"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-3.17" && (".tekton/gatekeeper-operator-[!b]*.yaml".pathChanged() ||  "build/Dockerfile*".pathChanged() || "go.(mod|sum)".pathChanged() ||  "main.go".pathChanged() || "(api|pkg|controllers)/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: gatekeeper-operator-3-17

--- a/.tekton/gatekeeper-operator-bundle-3-17-pull-request.yaml
+++ b/.tekton/gatekeeper-operator-bundle-3-17-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-3.17"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-3.17" && (".tekton/gatekeeper-operator-bundle-*.yaml".pathChanged() || "bundle.Dockerfile*".pathChanged() || "bundle/***".pathChanged() || "build/konflux-patch.sh".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: gatekeeper-operator-3-17

--- a/.tekton/gatekeeper-operator-bundle-3-17-push.yaml
+++ b/.tekton/gatekeeper-operator-bundle-3-17-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-3.17"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-3.17" && (".tekton/gatekeeper-operator-bundle-*.yaml".pathChanged() || "bundle.Dockerfile*".pathChanged() || "bundle/***".pathChanged() || "build/konflux-patch.sh".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: gatekeeper-operator-3-17


### PR DESCRIPTION
Konflux will build an image for the operator or bundle's containerfile and that containerfile's
dependencies.

It honestly makes me a bit hesitant to restrict the builds so much since they're so wide open right now, but I think the restriction here ultimately makes sense, but I'd appreciate reviewers' thoughts on it in case I missed something!

And in case you're wondering about the triple asterisk like I was, it's not a typo--it's some weird PipelinesAsCode thing it seems: https://pipelinesascode.com/docs/guide/matchingevents/

ref: https://issues.redhat.com/browse/ACM-15393