### PR TITLE
Enable Dockerfile image updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,29 @@
   "timezone": "America/New_York",
   "gomod": {
     "enabled": false
-  }
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["dockerfile"],
+      "enabled": false
+    },
+    {
+      "groupName": "Bundle builder image update",
+      "matchBaseBranches": ["/^release-[0-9]+\\.[0-9]+$/"],
+      "matchManagers": ["dockerfile"],
+      "managerFilePatterns": ["build/bundle.Dockerfile.rhtap"],
+      "ignorePaths": ["*"],
+      "enabled": true,
+      "pinDigests": false
+    },
+    {
+      "groupName": "Operator base image update",
+      "matchBaseBranches": ["/^release-[0-9]+\\.[0-9]+$/"],
+      "matchManagers": ["dockerfile"],
+      "managerFilePatterns": ["build/*Dockerfile.rhtap"],
+      "ignorePaths": ["*"],
+      "enabled": true,
+      "pinDigests": true
+    }
+  ]
 }


### PR DESCRIPTION
This enables MintMaker Dockerfile updates for the images in `build/*Dockerfile.rhtap`. It sets `pinDigests` so that, when updating, it specifies the digest next to the tag, like:

```
FROM registry.access.redhat.com/ubi9:latest@sha256:<sha256>
```

It also keeps the bundle up-to-date but without pinning a digest since the bundle only leverages a builder for its CLIs and doesn't pass along any binaries to the resulting image.