### PR TITLE
[release-3.19] Handle image SHA

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -58,7 +58,7 @@ jobs:
         run: |
           diff \
             <(sed -E 's/FROM .*go([0-9.]+).* AS builder/FROM \1 AS builder/' build/Dockerfile) \
-            <(sed -E 's/FROM .*rhel_[0-9]+_([0-9.]+).* AS builder/FROM \1 AS builder/' build/Dockerfile.rhtap)
+            <(sed -E 's/FROM .*rhel_[0-9]+_([0-9.]+).* AS builder/FROM \1 AS builder/;s/FROM (.*\/ubi-minimal:latest).*/FROM \1/' build/Dockerfile.rhtap)
 
       - name: Unit and Integration Tests
         run: |


### PR DESCRIPTION
This permits digests to be pinned in the Konflux files while not requiring it in the regular containerfiles.
